### PR TITLE
課題回答画面のボタンデザイン変更など

### DIFF
--- a/src/main/resources/static/css/canvas.css
+++ b/src/main/resources/static/css/canvas.css
@@ -11,6 +11,16 @@ canvas{
     width: 100%;
     height: 100%;
 }
+.mybtn-secondary {
+    color: #fff;
+    background-color: #6c757d;
+    border-color: #6c757d;
+}
+.mybtn-secondary:not(:disabled):not(.disabled).active, .mybtn-secondary:not(:disabled):not(.disabled):active, .show>.mybtn-secondary.dropdown-toggle {
+    color: #fff;
+    background-color: #17a2b8;
+    border-color: #4e555b;
+}
 
 @media screen and ( max-width:500px) {
     /*　画面サイズが500pxまではここを読み込む　*/

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -7,9 +7,6 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width">
-  <!-- /* 各画面専用のCSSを定義 */ -->
-  <!-- /* ${変数}について?で存在条件分岐をかけて、:以降のelse部分に_(処理なしトークン)を記述 */ -->
-  <th:block th:replace="${links} ?: _"/>
   <!-- /* 各画面専用のjavascriptを定義 */ -->
   <th:block th:replace="${scripts} ?: _" />
 
@@ -22,6 +19,11 @@
     th:href="@{/webjars/bootstrap/4.5.0/css/bootstrap.min.css}" />
   <script th:src="@{/webjars/jquery/3.4.0/jquery.slim.min.js}" type="text/javascript" charset="utf-8"></script>
   <script th:src="@{/webjars/bootstrap/4.5.0/js/bootstrap.bundle.min.js}" type="text/javascript" charset="utf-8"></script>
+
+  <!-- /* 各画面専用のCSSを定義 */ -->
+  <!-- /* ${変数}について?で存在条件分岐をかけて、:以降のelse部分に_(処理なしトークン)を記述 */ -->
+  <th:block th:replace="${links} ?: _"/>
+  
   <style type="text/css">
 .dropdown:hover .dropdown-menu {
     display: block;

--- a/src/main/resources/templates/student/selfstudy/question.html
+++ b/src/main/resources/templates/student/selfstudy/question.html
@@ -57,7 +57,7 @@
   </div>
   
   <div class="btn-group btn-group-toggle" data-toggle="buttons" style="width: 100%;">
-    <label class="btn btn-secondary" th:each="answerItem : ${answerSelectedItems}">
+    <label class="btn mybtn-secondary" th:each="answerItem : ${answerSelectedItems}">
       <input type="radio" name="answer" th:id="${answerItem.key}" th:value="${answerItem.key}" th:checked="${answerItem.key.equals(selfStudyQuestionForm.answer)}" th:text="${answerItem.value}" autocomplete="off"></label>
     </label>
   </div>

--- a/src/main/resources/templates/student/selfstudy/question_confirm.html
+++ b/src/main/resources/templates/student/selfstudy/question_confirm.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head th:replace="layout :: common_layout(title = '自習回答確認画面', scripts = ~{::script}, links = ~{::link})">
+<link href="../static/css/canvas.css" th:href="@{/css/canvas.css}" rel="stylesheet"></link>
 </head>
 <body>
 
@@ -49,7 +50,7 @@
   
 
   <div class="btn-group btn-group-toggle" data-toggle="buttons" style="width: 100%;">
-    <label class="btn btn-secondary" th:each="answerItem : ${answerSelectedItems}">
+    <label class="btn mybtn-secondary" th:each="answerItem : ${answerSelectedItems}">
       <input type="radio" name="questionForm.answer" th:value="${answerItem.key}" th:checked="${answerItem.key.equals(selfStudyQuestionForm.answer)}" autocomplete="off" disabled/>
       <label th:if="${answerItem.key.equals(selfStudyQuestionForm.answer)}" th:text="${answerItem.value}" style="border-bottom: solid 3px #ff0000;"></label>
       <label th:if="${!answerItem.key.equals(selfStudyQuestionForm.answer)}" th:text="${answerItem.value}" ></label>

--- a/src/main/resources/templates/student/task/question.html
+++ b/src/main/resources/templates/student/task/question.html
@@ -30,7 +30,7 @@
     </div>
   </div>
   
-  <div class="form-row">
+  <div class="form-row" id="writeButton">
     <button type="button" id="pen_active_btn" class="btn btn btn-outline-primary" data-toggle="button" aria-pressed="false" autocomplete="off">
       書き込み
     </button>

--- a/src/main/resources/templates/student/task/question.html
+++ b/src/main/resources/templates/student/task/question.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head th:replace="layout :: common_layout(title = '課題回答画面', scripts = ~{::script}, links = ~{::link})">
   <script th:src="@{/js/canvaspen.js}"></script>
+  <link href="../static/css/canvas.css" th:href="@{/css/canvas.css}" rel="stylesheet"></link>
 </head>
 <body>
 
@@ -63,12 +64,11 @@
 	  <input type="hidden" name="questionForm.fieldSId" th:value="*{questionForm.fieldSId}">
 	</div>
   </div>
-  
-  <div class="form-row mt-5">
-    <div class="form-check form-check-inline col-md-3 m-0 p-0" th:each="answerItem : ${answerSelectedItems}">
-      <input class="form-check-input" type="radio" name="questionForm.answer" th:id="${answerItem.key}" th:value="${answerItem.key}" th:checked="${answerItem.key.equals(taskForm.questionForm.answer)}" />
-      <label class="form-check-label" th:text="${answerItem.value}" th:for="${answerItem.key}"></label>
-    </div>
+
+  <div class="btn-group btn-group-toggle" data-toggle="buttons" style="width: 100%;">
+    <label class="btn mybtn-secondary" th:each="answerItem : ${answerSelectedItems}">
+      <input type="radio" name="questionForm.answer" th:id="${answerItem.key}" th:value="${answerItem.key}" th:checked="${answerItem.key.equals(taskForm.questionForm.answer)}" th:text="${answerItem.value}" autocomplete="off"></label>
+    </label>
   </div>
   
   <div class="form-row  mt-5">

--- a/src/main/resources/templates/student/task/question_confirm.html
+++ b/src/main/resources/templates/student/task/question_confirm.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head th:replace="layout :: common_layout(title = '課題回答確認画面', scripts = ~{::script}, links = ~{::link})">
+  <link href="../static/css/canvas.css" th:href="@{/css/canvas.css}" rel="stylesheet"></link>
  </head>
 <body>
 
@@ -59,16 +60,12 @@
     </div>
   </div>
   
-  <div class="form-row mt-5">
-    <div class="form-check form-check-inline col-md-3 m-0 p-0" th:each="answerItem : ${answerSelectedItems}">
-      <input class="form-check-input" type="radio" name="questionForm.answer" th:value="${answerItem.key}" th:checked="${answerItem.key.equals(taskForm.questionForm.answer)}" disabled />
-      <font th:if="${answerItem.key.equals(taskForm.questionForm.answer)}" style="border-bottom: solid 4px red;">
-        <label class="form-check-label" th:text="${answerItem.value}"></label>
-      </font>
-      <font th:if="${!answerItem.key.equals(taskForm.questionForm.answer)}">
-        <label class="form-check-label" th:text="${answerItem.value}"></label>
-      </font>
-    </div>
+  <div class="btn-group btn-group-toggle" data-toggle="buttons" style="width: 100%;">
+    <label class="btn mybtn-secondary" th:each="answerItem : ${answerSelectedItems}">
+      <input type="radio" name="questionForm.answer" th:value="${answerItem.key}" th:checked="${answerItem.key.equals(taskForm.questionForm.answer)}" autocomplete="off" disabled/>
+      <label th:if="${answerItem.key.equals(taskForm.questionForm.answer)}" th:text="${answerItem.value}" style="border-bottom: solid 3px #ff0000;"></label>
+      <label th:if="${!answerItem.key.equals(taskForm.questionForm.answer)}" th:text="${answerItem.value}" ></label>
+    </label>
   </div>
   
   <div class="form-row  mt-5">


### PR DESCRIPTION
- bootstrapを上書きしたかったため、bootstrapロード後にcanvas.cssをロードするよう変更しました。
- 選択肢ボタンを押下した後の色の変更しました。
- 課題回答画面、課題回答確認画面を自習の画面を同じようにしました。

![Screenshot_20201229_132037~2](https://user-images.githubusercontent.com/44247357/103259301-20642980-49dc-11eb-90f9-e9c281782bd8.jpg)

![Screenshot_20201229_130319](https://user-images.githubusercontent.com/44247357/103259310-278b3780-49dc-11eb-85c1-d0a58e2f88dc.jpg)
